### PR TITLE
Docker 기반 CI/CD 파이프라인 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,5 +42,6 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "spring.profiles.active", "test"  // 테스트 실행 시 test 프로파일 활성화
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+services:  # 여러 컨테이너를 정의하는 블록
+  mysql:  # MySQL 서비스 정의
+    image: mysql:8.0  # 사용할 Docker 이미지
+    container_name: mysql-container  # 컨테이너 이름
+    ports:
+      - "3307:3306"  # 호스트:컨테이너 포트
+    environment:  # 환경 변수 설정
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: gear4camp  # 기본 생성할 데이터베이스 이름
+    volumes:
+      - mysql_data:/var/lib/mysql  # 볼륨 마운트 설정
+    networks:
+      - my-network  # 네트워크 그룹
+
+  app:  # 애플리케이션 컨테이너
+    build: .  # 현재 디렉토리에서 Dockerfile을 빌드
+    ports:
+      - "8080:8080"  # 애플리케이션 포트
+    depends_on:
+      - mysql  # MySQL이 먼저 실행되도록 설정
+    networks:
+      - my-network  # 네트워크 그룹
+
+networks:  # 네트워크 정의
+  my-network:
+    driver: bridge  # 네트워크 드라이버
+
+volumes:
+  mysql_data:  # 볼륨 설정

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,7 @@
 spring.application.name=gear4camp
 
 # MySQL
-#spring.datasource.url=jdbc:mysql://localhost:3306/gear4camp?serverTimezone=UTC&characterEncoding=UTF-8
-spring.datasource.url=jdbc:mysql://localhost:3307/gear4camp?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://mysql-container:3306/gear4camp?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/gear4camp?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
mysql 연동 및 회원 CRUD 틀 적용(임시)

CI/CD 파이프라인 설정 추가

GitHub Actions를 이용하여 CI/CD 파이프라인 구성
Docker 이미지를 자동으로 빌드하고 Docker Hub에 푸시
dev와 main 브랜치에 푸시 또는 PR 발생 시 트리거
Docker 이미지: jinyeonseok/gear4camp:latest
향후 개선 사항

AWS 서버와 연동하여 자동 배포까지 적용 예정

git action ci/cd 중 테스트 실패로 인해 테스트는 test 전용 properties로 설정된 부분으로 진행